### PR TITLE
[panda] Skip scout option is not available on pchain

### DIFF
--- a/shrek/scripts/buildCommonWorklow.py
+++ b/shrek/scripts/buildCommonWorklow.py
@@ -314,6 +314,10 @@ def cwl_steps( wfgraph, site, args ):
         steps += ' "'
 
         optargs = cwl_opt_args(job)
+
+        if args.scouting == False:
+            optargs += " --expertOnly_skipScout "
+        
         if len(optargs.strip()) > 0:
             steps += "\n        opt_args:"
             steps += '\n          default: "%s --site %s --avoidVP --noBuild "' %(optargs,site)

--- a/shrek/scripts/submitWorflowToPanDA.py
+++ b/shrek/scripts/submitWorflowToPanDA.py
@@ -268,9 +268,6 @@ def main():
     
         pchain . append ( "pchain" )
 
-        if args.scouting == False:
-            pchain . append( '--expertOnly_skipScout' )
-
         pchain . append( '--vo %s'%args.vo )
         pchain . append( '--workingGroup %s'%args.workingGroup )
         pchain . append( '--prodSourceLabel %s'%args.prodSourceLabel )


### PR DESCRIPTION
... move the expert only option down into the CWL document when we execute the prun command.  Note, as implemented, this is a global option for the entire workflow, which is applied at the command line.