### PR TITLE
The workflow tests require an "argument-like" object, because they

### DIFF
--- a/tests/test_more_complicated_example.py
+++ b/tests/test_more_complicated_example.py
@@ -22,6 +22,7 @@ def commonWorkflow():
         offset = 0
         site = "BNL_OSG_SPHENIX"
         tag  = "sP-MORE-COMPLICATED-CHAIN-TEST"
+        scouting = True
     args = Args()        
 
     return buildCommonWorkflow( yamls, args.tag, args.site, args, {} )    

--- a/tests/test_pythia8_charm_simulation.py
+++ b/tests/test_pythia8_charm_simulation.py
@@ -27,6 +27,7 @@ def commonWorkflow():
         offset = 0
         site = "BNL_OSG_SPHENIX"
         tag  = "sP-PYTHIA8-TEST"
+        scouting = True
     args = Args()        
 
     return buildCommonWorkflow( yamls, args.tag, args.site, args, {} )

--- a/tests/test_simple_chain.py
+++ b/tests/test_simple_chain.py
@@ -18,6 +18,7 @@ def commonWorkflow():
         offset = 0
         site = "BNL_OSG_SPHENIX"
         tag  = "sP-SIMPLE-CHAIN-TEST"
+        scouting = True
     args = Args()
 
     return buildCommonWorkflow( yamls, args.tag, args.site, args, {} )    


### PR DESCRIPTION
exercise functionality that depends on the command line arguments. Because we branch on the scouting option, the mocked argument object needs to specify whether to perform scouting or not (even though we don't feed any actual pandas in these tests.)