### PR TITLE
[pandaopts] Allow CLI substitution for panda prun options

### DIFF
--- a/shrek/scripts/buildCommonWorklow.py
+++ b/shrek/scripts/buildCommonWorklow.py
@@ -193,7 +193,7 @@ def cwl_outputs( wfgraph ):
 
 
 
-def cwl_opt_args( job ):
+def cwl_opt_args( job, glvars ):
 
     optargs = ""
 
@@ -206,6 +206,9 @@ def cwl_opt_args( job ):
         val = getattr(params,par,None)
 
         if val:
+
+            val = glvars.get( val, val )            
+            
             if par=='merge':
                 optargs += ' --mergeOutput --mergeScript=\\\"%s\\\"' % val
             else:            
@@ -296,7 +299,7 @@ def cwl_opt_args( job ):
         
     return optargs
 
-def cwl_steps( wfgraph, site, args ):
+def cwl_steps( wfgraph, site, args, glvars ):
     steps=""
     G = wfgraph.graph
 
@@ -347,7 +350,7 @@ def cwl_steps( wfgraph, site, args ):
         steps += ' >& _%s.log' % ( job.name ) 
         steps += ' "'
 
-        optargs = cwl_opt_args(job)
+        optargs = cwl_opt_args(job, glvars)
 
         if args.scouting == False:
             optargs += " --expertOnly_skipScout "
@@ -386,7 +389,7 @@ def buildCommonWorkflow( yamllist, tag_, site, args, glvars_ ):
     output += cwl_requirements()
     output += cwl_inputs( wfg )
     output += cwl_outputs( wfg )
-    output += cwl_steps( wfg, site, args )
+    output += cwl_steps( wfg, site, args, glvars_ )
 
     yaml = ""
     yaml += yml_inputs( wfg, glvars_ )

--- a/shrek/scripts/submitWorflowToPanDA.py
+++ b/shrek/scripts/submitWorflowToPanDA.py
@@ -53,7 +53,7 @@ def progressbar(it, prefix="", size=60, out=sys.stdout): # Python3.3+
     print("\n", flush=True, file=out)
                                                                 
 
-def buildPrunCommand( submissionDirectory, jobDefinitions, args, taguuid  ):  
+def buildPrunCommand( submissionDirectory, jobDefinitions, args, glvars, taguuid  ):  
     assert( len(jobDefinitions)==1 )
     from shrek.scripts.buildCommonWorklow import PANDA_OPTS
     
@@ -180,8 +180,11 @@ def buildPrunCommand( submissionDirectory, jobDefinitions, args, taguuid  ):
     params = job.parameters
     hasMaxAttempt = False
     for par in PANDA_OPTS:
-        val = getattr(params,par,None)
+        val = getattr(params,par,None)        
         if val:
+
+            val = glvars.get( val, val )
+
             if par=='merge':
                 pchain.append( '--mergeOutput' )
                 pchain.append( '--mergeScript=\\\"%s\\\"' % val )
@@ -344,7 +347,7 @@ def main():
     if len(jobs)==1:
         WARN("Single job description (yaml) found.")
         WARN("This looks like a prun job to me")
-        pruncmd = buildPrunCommand( subdir, jobs, args, taguuid )
+        pruncmd = buildPrunCommand( subdir, jobs, args, glvars, taguuid )
         # Do not execute workflow check
         if args.check==True:
             WARN("Setting option --no-check")


### PR DESCRIPTION
Allows users to specify tokens in their job descriptions (yaml files) which will be substituted for by command line parameters during shrek invocation.  For example:

simple.yaml
```
Parameters:                                                                                                                                                                                                                                                                         
  name: simple
  nJobs: NJOBS                                                                                                                                                                                                                                                                      

OutputDataSets:                                                                                                                                                                                                                                                                     
  - name: simple/outDS                                                                                                                                                                                                                                                                 
    filelist:                                                                                                                                                                                                                                                                       
      - "required: simple.txt"                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                    
JobCommands: |-                                                                                                                                                                                                                                                                     
  echo $uniqueId $@ > simple.txt                                                                                                                                                                                                                                                      
```

When invoked with `shrek --NJOBS=5 --submit --tag=simple simple.yaml`, the NJOBS token will be replaced on the prun command line with 5.