### PR TITLE
[pandaopts] Add pfnList option.

### DIFF
--- a/shrek/scripts/buildCommonWorklow.py
+++ b/shrek/scripts/buildCommonWorklow.py
@@ -42,6 +42,7 @@ PANDA_OPTS = [ "nJobs",
                "processingType",
                # "nEventsPerFile",  # These are attached to inputs
                # "nEventsPerChunk",
+               "pfnList",           
                "writeInputToTxt",
                "maxNFilesPerJob",
                "cpuTimePerEvent",
@@ -346,9 +347,18 @@ def cwl_steps( wfgraph, site, args, glvars ):
         # Jobs have a unique identifier (starting at 1)
         steps += " %%RNDM:%i" % ( args.offset )
 
+        # PanDA will substitute the input files for %IN %IN2 %IN3 etc... 
         for (i,IN) in enumerate(job.inputs):
             if i==0: steps += " %IN"
             else   : steps += " %%IN%i"%(i+1)
+
+        # If we specified a pfnList in job parameters, add the %IN tag
+        pfnlist = getattr(job.parameters,'pfnList',None)
+        if pfnlist != None:
+            steps += " %IN"
+
+
+                
         steps += ' >& _%s.log' % ( job.name ) 
         steps += ' "'
 

--- a/shrek/scripts/buildJobScript.py
+++ b/shrek/scripts/buildJobScript.py
@@ -114,6 +114,18 @@ def buildJobScript( yaml_, tag_, opts_, glvars_ ):
             arg = arg + 1
 
         #
+        # Alternatively we may have a pfnlist specified in the parameter
+        # block.  If so, set that up as IN1
+        #
+        try:
+            pfnlist=job.parameters.pfnList
+            output += "export IN1_name=pfnlist_%s\n"%pfnlist
+            output += "export IN1_task=%s\n"%pfnlist
+            output += "export IN1=%s\n"%pfnlist            
+        except AttributeError:
+            pass
+
+        #
         # Set the tag
         #
         output += 'export shrek_tag=%s\n'%(tag_)


### PR DESCRIPTION
The user can specify a pfnList.  When specified, the contents of the file which is referenced will be copied into the submission directory, and from there to the PanDA server and worker node.  (Thus the contents must be lightweight and cannot be, e.g., datafiles).  This is meant to deal with the case where local files are used to spawn jobs.