### PR TITLE
Parameterize ds inputs

### DIFF
--- a/shrek/scripts/buildCommonWorklow.py
+++ b/shrek/scripts/buildCommonWorklow.py
@@ -163,6 +163,8 @@ def yml_inputs( wfgraph, glvars_ ):
             #inputs += "\n  %s: string"%inp.name
             if inp.datasets:
                 dataset = inp.datasets
+                if '$' in dataset:
+                    dataset=dataset.replace('$','')
                 for k,v in glvars_.items():
                     if k in dataset:
                         dataset = dataset.replace(k,v)

--- a/shrek/scripts/submitWorflowToPanDA.py
+++ b/shrek/scripts/submitWorflowToPanDA.py
@@ -155,7 +155,11 @@ def buildPrunCommand( submissionDirectory, jobDefinitions, args, glvars, taguuid
         # Handle principle (input) data set
         if count==1:
             hasInput = True
-            pchain .append( ' --inDS %s'%(inp.datasets))
+            dataset = inp.datasets
+            if '$' in dataset:
+                dataset=dataset.replace('$','')
+                dataset=glvars.get( dataset, None )
+            pchain .append( ' --inDS %s'%(dataset))
             if nfpj:
                 pchain.append( ' --nFilesPerJob='+str(nfpj) )
             if nepf:


### PR DESCRIPTION
Add command-line parameterization of input datasets for prun inputs.

Modify the CWL builder to handle environment variable definition of parameterized inputs.